### PR TITLE
minimal python version supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ packages =
     nodezator.menu
     nodezator.menu.submenu
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.8
 install_requires =
     pygame
     numpy


### PR DESCRIPTION
i think it's 3.8 because :

### 3.6 (EOL)

```
Traceback (most recent call last):
  File "/Users/user/.local/bin/nodezator", line 10, in <module>
    sys.exit(main())
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/__main__.py", line 66, in main
    raise err
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/__main__.py", line 54, in main
    try: from mainloop import run_app
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/mainloop.py", line 52, in <module>
    from winman.main import perform_startup_preparations
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/winman/main.py", line 57, in <module>
    from editing.main import EditingAssistant
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/editing/main.py", line 12, in <module>
    from editing.objinsert   import ObjectInsertionRemoval
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/editing/objinsert.py", line 27, in <module>
    from graphman.operatornode.main import OperatorNode
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/graphman/operatornode/main.py", line 10, in <module>
    from graphman.operatornode.vizprep import (
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/graphman/operatornode/vizprep.py", line 13, in <module>
    from graphman.operatornode.surfs import (
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/graphman/operatornode/surfs.py", line 24, in <module>
    from graphman.operatornode.constants import (
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/graphman/operatornode/constants.py", line 114, in <module>
    for key, callable_obj in OPERATIONS_MAP.items()
  File "/Users/user/.local/lib/python3.6/site-packages/nodezator/graphman/operatornode/constants.py", line 114, in <dictcomp>
    for key, callable_obj in OPERATIONS_MAP.items()
  File "/usr/lib64/python3.6/inspect.py", line 3037, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped)
  File "/usr/lib64/python3.6/inspect.py", line 2787, in from_callable
    follow_wrapper_chains=follow_wrapped)
  File "/usr/lib64/python3.6/inspect.py", line 2266, in _signature_from_callable
    skip_bound_arg=skip_bound_arg)
  File "/usr/lib64/python3.6/inspect.py", line 2090, in _signature_from_builtin
    raise ValueError("no signature found for builtin {!r}".format(func))
ValueError: no signature found for builtin <built-in function add>
```

### 3.7
```
Traceback (most recent call last):
  File "/Users/user/.local/bin/nodezator", line 8, in <module>
    sys.exit(main())
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/__main__.py", line 72, in main
    run_app(filepath)
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/mainloop.py", line 203, in run_app
    raise err
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/mainloop.py", line 92, in run_app
    loop_holder.handle_input()
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/menu/behaviour.py", line 222, in handle_input
    self.invoke_hovered_widget()
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/menu/hover.py", line 402, in invoke_hovered_widget
    try: method()
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/winman/fileop.py", line 163, in new
    save_pyl({}, filepath)
  File "/Users/user/.local/lib/python3.7/site-packages/nodezator/ourstdlibs/pyl.py", line 49, in save_pyl
    sort_dicts = sort_dicts,
TypeError: pformat() got an unexpected keyword argument 'sort_dicts'
```