### PR TITLE
Add `if __name__ == '__main__'` block on graph exported as Python

### DIFF
--- a/nodezator/graphman/pythonrepr.py
+++ b/nodezator/graphman/pythonrepr.py
@@ -373,6 +373,12 @@ def python_repr(self, additional_levels=()):
       + docstring
 
       + graph_function_body
+      
+      + '\n\n'
+      
+      + 'if __name__ == "__main__":\n'
+      
+      + f'    {func_name}()\n\n'
 
     )
 


### PR DESCRIPTION
Python module created from node graph could not be used "as is" as executable script, because it does not call the generated function. This patch adds the necessary code to do so.